### PR TITLE
Make pip installable and add CLI entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,24 @@ Wikipedia [Source](http://www.mattmahoney.net/dc/textdata) [Preprocessed](http:/
 
 [Flickr](http://leitang.net/code/social-dimension/data/flickr.mat)
 
+## Installation
+
+The latest version of NetMF can be downloaded and installed from
+[GitHub](https://github.com/xptree/NetMF) on Python 3.5+ with:
+
+```bash
+$ pip install git+https://github.com/xptree/NetMF.git
+```
+
+For developers, NetMF can be installed from the source code in
+in development mode with:
+
+```bash
+$ git clone https://github.com/xptree/NetMF.git
+$ cd NetMF
+$ pip install -e .
+```
+
 ## Usage
 
 This is a minimal example to use the code via the command line to train on the PPI network.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ Wikipedia [Source](http://www.mattmahoney.net/dc/textdata) [Preprocessed](http:/
 
 [Flickr](http://leitang.net/code/social-dimension/data/flickr.mat)
 
+## Usage
+
+This is a minimal example to use the code via the command line to train on the PPI network.
+
+```bash
+$ wget http://snap.stanford.edu/node2vec/Homo_sapiens.mat
+$ netmf-train --input Homo_sapiens.mat --output homo_sapiens_embeddings.txt
+$ netmf-predict --label Homo_sapiens.mat --embedding homo_sapiens_embeddings.txt.npy --seed 5
+```
+
 ## Cite
 
 Please cite our paper if you use this code in your own work:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,44 @@
+##########################
+# Setup.py Configuration #
+##########################
+# Configuring setup()
+[metadata]
+name = netmf
+version = 0.0.1
+
+# Author information
+author = Jiezhong Qiu
+
+# License information
+license = MIT
+license_file = LICENSE
+
+# Search tags
+classifiers =
+    Development Status :: 4 - Beta
+    Environment :: Console
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Topic :: Scientific/Engineering :: Artificial Intelligence
+keywords =
+    Node Representation Learning
+    Network Representation Learning
+
+[options]
+install_requires =
+    scipy
+    numpy
+    theano
+    sklearn
+
+python_requires = >=3.5
+
+# Where is my code
+packages = find:
+package_dir =
+    = src
+
+[options.packages.find]
+where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,3 +42,8 @@ package_dir =
 
 [options.packages.find]
 where = src
+
+[options.entry_points]
+console_scripts =
+    netmf-train = netmf.netmf:main
+    netmf-predict = netmf.predict:main

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+"""Setup module."""
+
+import setuptools
+
+if __name__ == '__main__':
+    setuptools.setup()

--- a/src/netmf/netmf.py
+++ b/src/netmf/netmf.py
@@ -122,7 +122,7 @@ def netmf_small(args):
     logger.info("Save embedding to %s", args.output)
     np.save(args.output, deepwalk_embedding, allow_pickle=False)
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--input", type=str, required=True,
             help=".mat input file path")
@@ -155,3 +155,6 @@ if __name__ == "__main__":
     else:
         netmf_small(args)
 
+
+if __name__ == "__main__":
+    main()

--- a/src/netmf/predict.py
+++ b/src/netmf/predict.py
@@ -88,7 +88,7 @@ def predict_cv(X, y, train_ratio=0.2, n_splits=10, random_state=0, C=1.):
             np.mean(macro) * 100)
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--label", type=str, required=True,
             help="input file path for labels (.mat)")
@@ -136,3 +136,6 @@ if __name__ == "__main__":
         predict_cv(embedding, label, train_ratio=tr/100.,
                 n_splits=args.num_split, C=args.C, random_state=args.seed)
 
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR closes #5 by putting the code in a directory structure that's required by python packages, by adding a minimal `setup.py`/`setup.cfg`.

It also closes #6 by encapsulating the main functionality (that used to live under the `if __name__ == '__main__'` block) with functions, then by adding the `[options.entry_points]` header to `setup.cfg`.

I also added an example in the README on how to run the code on one of the examples presented in your paper. I'm a big fan of DeepWalk and related methods, and I appreciate the incredible work you did to push the theoretical side of it. I hope this PR is helpful for you, and many others!